### PR TITLE
Fix display of time units as per the SI

### DIFF
--- a/src/ProtonVPN.App/Core/MVVM/Converters/SecondsToTimeConverter.cs
+++ b/src/ProtonVPN.App/Core/MVVM/Converters/SecondsToTimeConverter.cs
@@ -37,20 +37,20 @@ namespace ProtonVPN.Core.MVVM.Converters
 
             if (seconds < 60)
             {
-                return $"{ts:%s}s";
+                return $"{ts:%s} s";
             }
 
             if (seconds < 3600)
             {
-                return $"{ts:%m}m {ts:%s}s";
+                return $"{ts:%m} min {ts:%s} s";
             }
 
             if (seconds < 86400)
             {
-                return $"{ts:%h}h {ts:%m}m {ts:%s}s";
+                return $"{ts:%h} h {ts:%m} min {ts:%s} s";
             }
 
-            return $"{ts:%d}d {ts:%h}h {ts:%m}m {ts:%s}s";
+            return $"{ts:%d} d {ts:%h} h {ts:%m} min {ts:%s} s";
         }
 
         public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)


### PR DESCRIPTION
The SI requires symbols (not abbreviations) for units and spaces
between quantities and their unit symbols. This commit fixes these
issues in the time formatter.