### PR TITLE
Fix missing plural form in French translation

### DIFF
--- a/src/Client/Localization/ProtonVPN.Client.Localization/Strings/fr-FR/Resources.resw
+++ b/src/Client/Localization/ProtonVPN.Client.Localization/Strings/fr-FR/Resources.resw
@@ -3061,7 +3061,7 @@ Une charge de serveur élevée peut ralentir votre connexion.</value>
     <value>Connexion</value>
   </data>
   <data name="Settings_Connection_AdvancedSettings">
-    <value>Paramètres Avancé</value>
+    <value>Paramètres avancés</value>
   </data>
   <data name="Settings_Connection_Advanced_AlternativeRouting">
     <value>Routage alternatif</value>


### PR DESCRIPTION
We currently show "Paramètres Avancé" which is incorrect both in terms of plural form **and** casing.
