### PR TITLE
Show change server button during connection for free users

### DIFF
--- a/src/Client/Logic/Connection/ProtonVPN.Client.Logic.Connection.Contracts/IChangeServerModerator.cs
+++ b/src/Client/Logic/Connection/ProtonVPN.Client.Logic.Connection.Contracts/IChangeServerModerator.cs
@@ -28,4 +28,6 @@ public interface IChangeServerModerator
     TimeSpan GetDelayUntilNextAttempt();
 
     TimeSpan GetRemainingDelayUntilNextAttempt();
+
+    bool HasTroubleConnecting();
 }

--- a/src/Client/Logic/Connection/ProtonVPN.Client.Logic.Connection/ChangeServerModerator.cs
+++ b/src/Client/Logic/Connection/ProtonVPN.Client.Logic.Connection/ChangeServerModerator.cs
@@ -39,12 +39,16 @@ public class ChangeServerModerator :
     IEventMessageReceiver<SettingChangedMessage>,
     IEventMessageReceiver<ConnectionStatusChangedMessage>
 {
+    private const int TroubleConnectingDelaySeconds = 6;
+
     private readonly ISettings _settings;
     private readonly IConnectionManager _connectionManager;
     private readonly IEventMessageSender _eventMessageSender;
 
     private ChangeServerSettings _changeServerSettings;
     private ChangeServerAttempts _changeServerAttempts;
+    private DateTimeOffset? _connectionStartTime;
+    private bool _isConnecting;
 
     protected override TimeSpan PollingInterval { get; } = TimeSpan.FromSeconds(1);
 
@@ -92,6 +96,17 @@ public class ChangeServerModerator :
             : TimeSpan.FromSeconds(Math.Ceiling(remainingTime.TotalSeconds));
     }
 
+    public bool HasTroubleConnecting()
+    {
+        if (!_isConnecting || !_connectionStartTime.HasValue)
+        {
+            return false;
+        }
+
+        TimeSpan elapsedTime = DateTimeOffset.UtcNow - _connectionStartTime.Value;
+        return elapsedTime.TotalSeconds >= TroubleConnectingDelaySeconds;
+    }
+
     public void Receive(LoggedInMessage message)
     {
         InvalidateChangeServerAttempts();
@@ -116,6 +131,20 @@ public class ChangeServerModerator :
 
     public void Receive(ConnectionStatusChangedMessage message)
     {
+        // Track connection state for HasTroubleConnecting logic
+        switch (message.ConnectionStatus)
+        {
+            case ConnectionStatus.Connecting:
+                _isConnecting = true;
+                _connectionStartTime = DateTimeOffset.UtcNow;
+                break;
+            case ConnectionStatus.Connected:
+            case ConnectionStatus.Disconnected:
+                _isConnecting = false;
+                _connectionStartTime = null;
+                break;
+        }
+
         if (_connectionManager.IsConnected &&
             _connectionManager.CurrentConnectionIntent?.Location is FreeServerLocationIntent intent &&
            intent.Kind == ConnectionIntentKind.Random)

--- a/src/Client/ProtonVPN.Client/UI/Main/Home/Upsell/ChangeServerComponentViewModel.cs
+++ b/src/Client/ProtonVPN.Client/UI/Main/Home/Upsell/ChangeServerComponentViewModel.cs
@@ -47,6 +47,7 @@ public partial class ChangeServerComponentViewModel : ActivatableViewModelBase,
     public double DelayInSeconds => _changeServerModerator.GetDelayUntilNextAttempt().TotalSeconds;
     public double RemainingDelayInSeconds => _changeServerModerator.GetRemainingDelayUntilNextAttempt().TotalSeconds;
     public string? FormattedRemainingTime => Localizer.GetFormattedShortTime(_changeServerModerator.GetRemainingDelayUntilNextAttempt());
+    public bool HasTroubleConnecting => _changeServerModerator.HasTroubleConnecting();
 
     public ChangeServerComponentViewModel(
         IConnectionManager connectionManager,
@@ -99,7 +100,10 @@ public partial class ChangeServerComponentViewModel : ActivatableViewModelBase,
 
     private bool CanChangeServer()
     {
-        return _connectionManager.IsConnected && _changeServerModerator.CanChangeServer();
+        bool isConnectedOrHasTroubleConnecting = _connectionManager.IsConnected || 
+                                                 (_connectionManager.IsConnecting && _changeServerModerator.HasTroubleConnecting());
+
+        return isConnectedOrHasTroubleConnecting && _changeServerModerator.CanChangeServer();
     }
 
     [RelayCommand]
@@ -115,6 +119,7 @@ public partial class ChangeServerComponentViewModel : ActivatableViewModelBase,
         OnPropertyChanged(nameof(DelayInSeconds));
         OnPropertyChanged(nameof(RemainingDelayInSeconds));
         OnPropertyChanged(nameof(FormattedRemainingTime));
+        OnPropertyChanged(nameof(HasTroubleConnecting));
 
         ChangeServerCommand.NotifyCanExecuteChanged();
     }


### PR DESCRIPTION
## ✨ Motivation / Context

Currently, on Windows, free users may experience connection hangs when a randomly selected server is unavailable or slow to respond. Unlike Android, there is no way to manually change the server until the connection is fully established, which may never happen in such cases.

On Android, however, the "Change Server" button becomes available after 6 seconds during the connection attempt, allowing the user to select a different server and successfully connect.

This PR brings the same UX improvement to the Windows client by enabling the button after 6 seconds during connection.

> **Note**: I was unable to test the changes due to project complexity and missing dependencies. Please consider this as a suggestion for improvement — the implementation is based on analysis of the current codebase and Android behavior.

---

## 🛠️ Summary of Changes

Align Windows client behavior with Android by showing the "Change Server" button during the connection process for free-tier users.

Previously, the button only appeared **after** the connection was successfully established. Now it appears **during** connection if it takes longer than 6 seconds, matching the Android implementation.

### 🔧 Code Changes:
- Added `HasTroubleConnecting()` method to `IChangeServerModerator` interface
- Implemented connection state tracking in `ChangeServerModerator`
- Updated `CanChangeServer` logic to allow server changes during connection
- Added `HasTroubleConnecting` property to `ChangeServerComponentViewModel`

---

## 📈 Expected Result

This improves the user experience for free-tier users experiencing slow or stuck connections by allowing them to change servers without waiting indefinitely for full connection establishment.