### PR TITLE
fix Log entries created from user input

### DIFF
--- a/src/Client/Files/ProtonVPN.Client.Files/Images/ImageCache.cs
+++ b/src/Client/Files/ProtonVPN.Client.Files/Images/ImageCache.cs
@@ -1,4 +1,4 @@
-﻿/*
+﻿﻿/*
  * Copyright (c) 2024 Proton AG
  *
  * This file is part of ProtonVPN.
@@ -19,6 +19,7 @@
 
 using System.Security.Cryptography;
 using System.Text;
+using System.Linq;
 using ProtonVPN.Api.Contracts;
 using ProtonVPN.Client.Files.Contracts.Images;
 using ProtonVPN.Common.Core.Extensions;
@@ -139,7 +140,7 @@ public class ImageCache : IImageCache
         }
         catch (Exception ex)
         {
-            _logger.Error<AppLog>($"Failed to download image using URL {downloadUrl}", ex);
+            _logger.Error<AppLog>($"Failed to download image using URL {SanitizeForLog(downloadUrl)}", ex);
         }
 
         return null;
@@ -183,5 +184,18 @@ public class ImageCache : IImageCache
         {
             _logger.Error<AppLog>($"Failed to delete the cached image '{cachedImage.LocalPath}'.", ex);
         }
+    }
+    /// <summary>
+    /// Sanitizes user input for safe logging by removing newlines and control characters.
+    /// </summary>
+    private static string SanitizeForLog(string input)
+    {
+        if (input == null)
+            return string.Empty;
+        // Remove CR, LF, and other control characters
+        var sanitized = input.Replace("\r", "").Replace("\n", "");
+        // Optionally, remove other non-printable characters
+        sanitized = new string(sanitized.Where(c => !char.IsControl(c)).ToArray());
+        return sanitized;
     }
 }

--- a/src/Client/Logic/Announcements/ProtonVPN.Client.Logic.Announcements.EntityMapping/AnnouncementMapper.cs
+++ b/src/Client/Logic/Announcements/ProtonVPN.Client.Logic.Announcements.EntityMapping/AnnouncementMapper.cs
@@ -1,4 +1,4 @@
-﻿/*
+﻿﻿/*
  * Copyright (c) 2025 Proton AG
  *
  * This file is part of ProtonVPN.
@@ -53,7 +53,7 @@ public class AnnouncementMapper : IMapper<AnnouncementResponse, Announcement>
             }
             else if (announcement is not null)
             {
-                _logger.Error<AppLog>($"Failed to fetch full screen image of announcement with ID '{leftEntity.Id}'.");
+                _logger.Error<AppLog>($"Failed to fetch full screen image of announcement with ID '{leftEntity.Id?.Replace("\r", "").Replace("\n", "")}'.");
             }
         }
         catch (Exception ex)

--- a/src/ProtonVPN.App/Core/Service/Vpn/AppController.cs
+++ b/src/ProtonVPN.App/Core/Service/Vpn/AppController.cs
@@ -1,4 +1,4 @@
-﻿/*
+﻿﻿/*
  * Copyright (c) 2023 Proton AG
  *
  * This file is part of ProtonVPN.
@@ -35,6 +35,11 @@ namespace ProtonVPN.Core.Service.Vpn
     {
         private readonly ILogger _logger;
 
+        private static string SanitizeForLog(string input)
+        {
+            if (input == null) return string.Empty;
+            return input.Replace("\r", "").Replace("\n", "");
+        }
         public event EventHandler<VpnStateIpcEntity> OnVpnStateChanged;
         public event EventHandler<PortForwardingStateIpcEntity> OnPortForwardingStateChanged;
         public event EventHandler<ConnectionDetailsIpcEntity> OnConnectionDetailsChanged;
@@ -49,9 +54,9 @@ namespace ProtonVPN.Core.Service.Vpn
 
         public async Task VpnStateChange(VpnStateIpcEntity state)
         {
-            _logger.Info<ProcessCommunicationLog>($"Received VPN Status '{state.Status}', NetworkBlocked: {state.NetworkBlocked} " +
-                $"Error: '{state.Error}', EndpointIp: '{state.EndpointIp}', Label: '{state.Label}', " +
-                $"VpnProtocol: '{state.VpnProtocol}', OpenVpnAdapter: '{state.OpenVpnAdapterType}'");
+            _logger.Info<ProcessCommunicationLog>($"Received VPN Status '{SanitizeForLog(state.Status)}', NetworkBlocked: {state.NetworkBlocked} " +
+                $"Error: '{SanitizeForLog(state.Error)}', EndpointIp: '{SanitizeForLog(state.EndpointIp)}', Label: '{SanitizeForLog(state.Label)}', " +
+                $"VpnProtocol: '{SanitizeForLog(state.VpnProtocol)}', OpenVpnAdapter: '{SanitizeForLog(state.OpenVpnAdapterType)}'");
             InvokeOnUiThread(() => OnVpnStateChanged?.Invoke(this, state));
         }
 

--- a/src/ProtonVPN.Vpn/Management/MessagingManagementChannel.cs
+++ b/src/ProtonVPN.Vpn/Management/MessagingManagementChannel.cs
@@ -1,4 +1,4 @@
-﻿/*
+﻿﻿/*
  * Copyright (c) 2023 Proton AG
  *
  * This file is part of ProtonVPN.
@@ -72,7 +72,9 @@ namespace ProtonVPN.Vpn.Management
         {
             if (!message.IsByteCount)
             {
-                _logger.Info<ProtocolLog>($"Management -> {message}");
+                // Sanitize message to prevent log forging
+                string sanitizedMessage = message.ToString().Replace("\r", "").Replace("\n", "");
+                _logger.Info<ProtocolLog>($"Management -> {sanitizedMessage}");
             }
         }
 


### PR DESCRIPTION
https://github.com/paliwangtel/win-app/blob/b0a94fd5dfd3d3ca1c8d14664b3d279dfde8faf5/src/Client/Files/ProtonVPN.Client.Files/Images/ImageCache.cs#L142-L142


https://github.com/paliwangtel/win-app/blob/b0a94fd5dfd3d3ca1c8d14664b3d279dfde8faf5/src/Client/Logic/Announcements/ProtonVPN.Client.Logic.Announcements.EntityMapping/AnnouncementMapper.cs#L56-L56

https://github.com/paliwangtel/win-app/blob/b0a94fd5dfd3d3ca1c8d14664b3d279dfde8faf5/src/ProtonVPN.App/Core/Service/Vpn/AppController.cs#L52-L54


If unsanitized user input is written to a log entry, a malicious user may be able to forge new log entries. Forgery can occur if a user provides some input with characters that are interpreted when the log output is displayed. If the log is displayed as a plain text file, then new line characters can be used by a malicious user. If the log is displayed as HTML, then arbitrary HTML may be include to spoof log entries.

--- 

Fix the problem, we need to sanitize the `downloadUrl` before logging it. Since the log entry is plain text, the recommended approach is to remove or replace newline characters and other control characters from the user input before including it in the log message. This can be done using `String.Replace` for `\r` and `\n`, and optionally for other control characters if desired. The fix should be applied directly at the point where the log entry is created, i.e., in `DownloadImageAsync` in `ImageCache.cs`. We will introduce a helper method to sanitize log input, and use it to clean `downloadUrl` before logging.

Specifically, we should remove any newline characters from `leftEntity.Id` before including it in the log message. This can be done using `String.Replace` to remove both `\r` and `\n` characters. The change should be made in `AnnouncementMapper.cs` on line 56, where the log entry is created. No new methods are needed, but we should ensure that the replacement is done inline in the log statement. No new imports are required, as `String.Replace` is part of the base class library.

The most important step is to remove or replace newline characters (`\r`, `\n`) from each field. This can be done using `String.Replace` or a helper method. The fix should be applied to all fields in the log message that come from `state` and could be tainted: `Status`, `Error`, `EndpointIp`, `Label`, `VpnProtocol`, and `OpenVpnAdapterType`. The changes should be made in the `VpnStateChange` method in `src/ProtonVPN.App/Core/Service/Vpn/AppController.cs`, specifically on line 52. If any of these fields are not strings, they should be converted to strings before sanitization.

A helper method (e.g., `SanitizeForLog(string input)`) can be added to the class to perform the sanitization. This method should replace all newline characters with an empty string or a safe substitute. The fix requires adding this method and using it for each relevant field in the log entry.

- In `MessagingManagementChannel.cs`, in the `Log(ReceivedManagementMessage message)` method, sanitize the string representation of `message` before logging.
- No new imports are needed, as `string.Replace` is part of the standard library.

### References
[Log Injection](https://www.owasp.org/index.php/Log_Injection)
[CWE-117](https://cwe.mitre.org/data/definitions/117.html)