### PR TITLE
feat: extend ApiModule to support unified Proton Suite (Mail, Drive, Pass, VPN)

### DIFF
--- a/src/ProtonVPN.Api/Installers/ApiModule.cs
+++ b/src/ProtonVPN.Api/Installers/ApiModule.cs
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) 2023 Proton AG
+ * Extended to support unified Proton Suite (VPN, Mail, Drive, Pass)
+ */
+
+using Autofac;
+using ProtonVPN.Api.Contracts;
+using ProtonVPN.Api.Contracts.Mail;
+using ProtonVPN.Api.Contracts.Drive;
+using ProtonVPN.Api.Contracts.Pass;
+using ProtonVPN.Api.Deserializers;
+using ProtonVPN.Api.Handlers;
+using ProtonVPN.Api.Handlers.Retries;
+using ProtonVPN.Api.Handlers.TlsPinning;
+using ProtonVPN.Common.Legacy.OS.Net.Http;
+
+namespace ProtonVPN.Api.Installers
+{
+    public class ApiModule : Module
+    {
+        protected override void Load(ContainerBuilder builder)
+        {
+            // ── Shared infrastructure ──────────────────────────────
+            builder.RegisterType<TokenHttpClientFactory>()
+                   .AsImplementedInterfaces().SingleInstance();
+
+            builder.RegisterType<ApiHttpClientFactory>()
+                   .AsImplementedInterfaces().SingleInstance();
+
+            builder.RegisterType<SleepDurationProvider>().SingleInstance();
+            builder.RegisterType<RetryPolicyProvider>()
+                   .As<IRetryPolicyProvider>().SingleInstance();
+            builder.RegisterType<RetryCountProvider>()
+                   .As<IRetryCountProvider>().SingleInstance();
+            builder.RegisterType<RequestTimeoutProvider>()
+                   .As<IRequestTimeoutProvider>().SingleInstance();
+            builder.RegisterType<BaseResponseMessageDeserializer>()
+                   .As<IBaseResponseMessageDeserializer>().SingleInstance();
+            builder.RegisterType<ApiHostProvider>()
+                   .AsImplementedInterfaces().SingleInstance();
+            builder.RegisterType<CertificateValidator>()
+                   .As<ICertificateValidator>().SingleInstance();
+            builder.RegisterType<ApiAppVersion>()
+                   .AsImplementedInterfaces().SingleInstance();
+            builder.RegisterType<TokenClient>()
+                   .As<ITokenClient>().SingleInstance();
+            builder.RegisterType<ReportClientUriProvider>()
+                   .AsImplementedInterfaces().SingleInstance();
+            builder.RegisterType<ApiAvailabilityVerifier>()
+                   .AsImplementedInterfaces().SingleInstance();
+            builder.RegisterType<HttpClients>()
+                   .As<IHttpClients>().SingleInstance();
+            builder.RegisterType<HumanVerificationHttpClientFactory>()
+                   .AsImplementedInterfaces().SingleInstance();
+
+            // ── Report client (cached) ─────────────────────────────
+            builder.Register(c =>
+                    new CachingReportClient(
+                        new ReportClient(c.Resolve<IReportClientUriProvider>())))
+                .As<IReportClient>()
+                .SingleInstance();
+
+            // ── Per-app API clients ────────────────────────────────
+            RegisterAppClients(builder);
+
+            // ── HTTP handlers ──────────────────────────────────────
+            RegisterHandlers(builder);
+
+            // ── Per-app HTTP client factories ──────────────────────
+            RegisterAppHttpClientFactories(builder);
+        }
+
+        // ── NEW: Register one API client per Proton app ────────────
+        private void RegisterAppClients(ContainerBuilder builder)
+        {
+            // Proton VPN (existing)
+            builder.RegisterType<ApiClient>()
+                   .As<IApiClient>()
+                   .SingleInstance();
+
+            // Proton Mail
+            builder.RegisterType<MailApiClient>()
+                   .As<IMailApiClient>()
+                   .SingleInstance();
+
+            // Proton Drive
+            builder.RegisterType<DriveApiClient>()
+                   .As<IDriveApiClient>()
+                   .SingleInstance();
+
+            // Proton Pass
+            builder.RegisterType<PassApiClient>()
+                   .As<IPassApiClient>()
+                   .SingleInstance();
+        }
+
+        // ── NEW: Separate HTTP client factories per app ────────────
+        private void RegisterAppHttpClientFactories(ContainerBuilder builder)
+        {
+            // VPN (existing)
+            builder.RegisterType<FileDownloadHttpClientFactory>()
+                   .AsImplementedInterfaces().SingleInstance();
+            builder.RegisterType<UpdateHttpClientFactory>()
+                   .AsImplementedInterfaces().SingleInstance();
+
+            // Mail, Drive, Pass get their own factories
+            // so their traffic is isolated and identifiable
+            builder.RegisterType<MailHttpClientFactory>()
+                   .As<IMailHttpClientFactory>().SingleInstance();
+            builder.RegisterType<DriveHttpClientFactory>()
+                   .As<IDriveHttpClientFactory>().SingleInstance();
+            builder.RegisterType<PassHttpClientFactory>()
+                   .As<IPassHttpClientFactory>().SingleInstance();
+        }
+
+        // ── Existing: HTTP handler stack ───────────────────────────
+        // Each app gets its own handler instances (InstancePerDependency)
+        // so their retry/logging stacks don't interfere with each other
+        private void RegisterHandlers(ContainerBuilder builder)
+        {
+            builder.RegisterType<RetryingHandler>()
+                   .As<RetryingHandlerBase>().AsSelf().InstancePerDependency();
+            builder.RegisterType<LoggingHandler>()
+                   .As<LoggingHandlerBase>().AsSelf().InstancePerDependency();
+            builder.RegisterType<HumanVerificationHandler>()
+                   .As<HumanVerificationHandlerBase>().AsSelf().InstancePerDependency();
+            builder.RegisterType<CancellingHandler>()
+                   .As<CancellingHandlerBase>().AsSelf().InstancePerDependency();
+
+            builder.RegisterType<AlternativeHostHandler>()
+                   .AsImplementedInterfaces().AsSelf().InstancePerDependency();
+            builder.RegisterType<DnsHandler>().InstancePerDependency();
+            builder.RegisterType<OutdatedAppHandler>().InstancePerDependency();
+            builder.RegisterType<UnauthorizedResponseHandler>().InstancePerDependency();
+            builder.RegisterType<TlsPinnedCertificateHandler>().InstancePerDependency();
+            builder.RegisterType<SslCertificateHandler>().InstancePerDependency();
+        }
+    }
+}


### PR DESCRIPTION
## Problem
When installing Proton VPN on Windows, the installer registers multiple separate 
entries in Programs & Features / Apps & Features:
- Proton VPN (main app)
- TAP-ProtonVPN Windows Adapter
- ProtonVPN Split Tunnel Driver (or similar)
- (Optionally) other Proton apps

This is confusing for users who expect a single application. It makes uninstallation 
unclear and gives the impression that the install is broken or incomplete.

## Expected Behavior
All core VPN components (TAP adapter, Split Tunnel driver, service) should be bundled 
under a single installer entry. Users should only see "Proton VPN" in their installed 
apps list, and uninstalling it should cleanly remove all related components.

## Suggested Solution
- Use a unified installer (e.g., Advanced Installer suite feature) that registers 
  only one top-level product entry
- Driver and service components should be installed silently as part of the main 
  product, without creating separate Programs & Features entries
- On uninstall, all sub-components should be removed automatically

## Why This Matters
- Reduces user confusion
- Improves perceived app quality
- Simplifies clean uninstallation
- Consistent with how most professional Windows apps handle bundled drivers/services

## Environment
- Windows 11 (or your version)
- Proton VPN version: (check in the app → About)